### PR TITLE
fix: procedure terminated before download start

### DIFF
--- a/canvassyncer/__main__.py
+++ b/canvassyncer/__main__.py
@@ -103,6 +103,8 @@ class CanvasSyncer:
             time.sleep(0.1)
         with self.countLock:
             self.threadCount += 1
+        with self.filesLock:
+            self.files.append(dst)
         tryTime = 0
         while tryTime <= 5:
             try:
@@ -110,8 +112,6 @@ class CanvasSyncer:
                 break
             except ConnectionError:
                 tryTime += 1
-        with self.filesLock:
-            self.files.append(dst)
         with open(dst + ".tmp", 'wb') as fd:
             for chunk in r.iter_content(512):
                 fd.write(chunk)


### PR DESCRIPTION
下载单个文件时若仍在线程中进行sess.get请求，sync函数会提前终止导致文件无法下载，把append提前可以解决这个问题？