### PR TITLE
Add Program Argument '--no-subfolder' 

### DIFF
--- a/canvassyncer/__main__.py
+++ b/canvassyncer/__main__.py
@@ -191,16 +191,22 @@ class CanvasSyncer:
 
     def createFolders(self, courseID, folders):
         for folder in folders.values():
-            path = os.path.join(self.downloadDir,
-                                f"{self.courseCode[courseID]}{folder}")
+            if self.config['no_subfolder']:
+                path = os.path.join(self.downloadDir, folder[1:])
+            else:
+                path = os.path.join(self.downloadDir,
+                                    f"{self.courseCode[courseID]}{folder}")
             if not os.path.exists(path):
                 os.makedirs(path)
 
     def getLocalFiles(self, courseID, folders):
         localFiles = []
         for folder in folders.values():
-            path = os.path.join(self.downloadDir,
-                                f"{self.courseCode[courseID]}{folder}")
+            if self.config['no_subfolder']:
+                path = os.path.join(self.downloadDir, folder[1:])
+            else:
+                path = os.path.join(self.downloadDir,
+                                    f"{self.courseCode[courseID]}{folder}")
             localFiles += [
                 os.path.join(folder, f).replace('\\', '/').replace('//', '/')
                 for f in os.listdir(path)
@@ -289,8 +295,11 @@ class CanvasSyncer:
         for fileName, (fileUrl, fileModifiedTimeStamp) in files.items():
             if not fileUrl:
                 continue
-            path = os.path.join(self.downloadDir,
-                                f"{self.courseCode[courseID]}{fileName}")
+            if self.config['no_subfolder']:
+                path = os.path.join(self.downloadDir, fileName[1:])
+            else:
+                path = os.path.join(self.downloadDir,
+                                    f"{self.courseCode[courseID]}{fileName}")
             path = path.replace('\\', '/').replace('//', '/')
             if fileName in localFiles:
                 localCreatedTimeStamp = int(os.path.getctime(path))
@@ -457,6 +466,9 @@ def run():
         parser.add_argument('-y',
                             help='confirm all prompts',
                             action="store_true")
+        parser.add_argument('--no-subfolder',
+                            help='do not create a course code named subfolder when synchronizing files',
+                            action="store_true")
         parser.add_argument('-p',
                             '--path',
                             help='appoint config file path',
@@ -492,6 +504,7 @@ def run():
         config = json.load(open(configPath, 'r', encoding='UTF-8'))
         config['y'] = args.y
         config['proxies'] = args.proxy
+        config['no_subfolder'] = args.no_subfolder
         Syncer = CanvasSyncer(config)
         Syncer.sync()
     except ConnectionError as e:


### PR DESCRIPTION
Add Program Argument '--no-subfolder' for Synchronizing Files WITHOUT a Subfolder.
Well, the motivation is from my course file folder arrangement:

2020 Fall/
    VE280/File/XXX
    VE280/Work/XXX
    VE215/File/XXX
    VE215/Work/XXX
    VV286/File/XXX
    VV286/Work/XXX

If I synchronize files by default, the files will be like

2020 Fall/
    VE280/File/VE280/XXX
    VE280/Work/XXX

which is not desired. So I modified some code and added a program argument to control this.

I do not have much experience in coding in python or improving the efficiency, so you may regard this pull request as some pseudocode, close this request and then implement it more elegantly by yourself.