### PR TITLE
Add keeping previous canvasURL feature

### DIFF
--- a/canvassyncer/__main__.py
+++ b/canvassyncer/__main__.py
@@ -352,9 +352,10 @@ def initConfig():
     elif os.path.exists("./canvassyncer.json"):
         oldConfig = json.load(open("./canvassyncer.json"))
     print("Generating new config file...")
-    url = input("Canvas url(Default: https://umjicanvas.com):").strip()
+    prevu = oldConfig.get('canvasURL', '') if oldConfig else "https://umjicanvas.com"
+    url = input("Canvas url(Defuault: " + prevu + "):").strip()
     if not url:
-        url = "https://umjicanvas.com"
+        url = prevu
     tipStr = f"(Default: {oldConfig.get('token', '')})" if oldConfig else ""
     token = input(f"Canvas access token{tipStr}:").strip()
     if not token:


### PR DESCRIPTION
Now when configuring, the syncer will keep the canvasURL unchanged if typed in nothing and previously have an value instread of using JI's URL. User experience outsitde of JI is expected to improve.