### PR TITLE
Change the default link and allow retry to handle 403 because of frequent visit

### DIFF
--- a/canvassyncer/__main__.py
+++ b/canvassyncer/__main__.py
@@ -61,7 +61,7 @@ class AsyncSemClient:
         retryTimes = 0
         checkError = bool(kwargs.pop("checkError", False))
         debugMode = bool(kwargs.pop("debug", False))
-        while (retryTimes <= 5):
+        while retryTimes <= 5:
             try:
                 async with self.sem:
                     resp = await self.client.get(*args, **kwargs)

--- a/canvassyncer/__main__.py
+++ b/canvassyncer/__main__.py
@@ -57,9 +57,9 @@ class AsyncSemClient:
                 print(text)
 
     async def json(self, *args, **kwargs):
-        retryTimes=0
+        retryTimes = 0
         checkError = bool(kwargs.pop("checkError", False))
-        while (retryTimes<=5):
+        while (retryTimes <= 5):
             try:
                 async with self.sem:
                     resp = await self.client.get(*args, **kwargs)
@@ -70,7 +70,7 @@ class AsyncSemClient:
                     exit(1)
                 return res
             except Exception:
-                retryTimes+=1
+                retryTimes += 1
         return res
 
     async def head(self, *args, **kwargs):

--- a/canvassyncer/__main__.py
+++ b/canvassyncer/__main__.py
@@ -353,7 +353,7 @@ def initConfig():
 
     print("Generating new config file...")
     url = promptConfigStr(
-        "Canvas url", "canvasURL", defaultValOnMissing="https://umjicanvas.com"
+        "Canvas url", "canvasURL", defaultValOnMissing="https://jicanvas.com"
     )
     token = promptConfigStr("Canvas access token", "token")
     courseCodesStr = promptConfigStr(

--- a/canvassyncer/__main__.py
+++ b/canvassyncer/__main__.py
@@ -57,14 +57,20 @@ class AsyncSemClient:
                 print(text)
 
     async def json(self, *args, **kwargs):
+        retryTimes=0
         checkError = bool(kwargs.pop("checkError", False))
-        async with self.sem:
-            resp = await self.client.get(*args, **kwargs)
-        res = resp.json()
-        if checkError and isinstance(res, dict) and res.get("errors"):
-            errMsg = res["errors"][0].get("message", "unknown error.")
-            print(f"\nError: {errMsg}")
-            exit(1)
+        while (retryTimes<=5):
+            try:
+                async with self.sem:
+                    resp = await self.client.get(*args, **kwargs)
+                res = resp.json()
+                if checkError and isinstance(res, dict) and res.get("errors"):
+                    errMsg = res["errors"][0].get("message", "unknown error.")
+                    print(f"\nError: {errMsg}")
+                    exit(1)
+                return res
+            except Exception:
+                retryTimes+=1
         return res
 
     async def head(self, *args, **kwargs):

--- a/canvassyncer/__main__.py
+++ b/canvassyncer/__main__.py
@@ -144,7 +144,7 @@ class CanvasSyncer:
     async def getCourseFoldersWithIDHelper(self, page, courseID):
         res = {}
         url = f"{self.baseUrl}/courses/{courseID}/folders?page={page}"
-        folders = await self.client.json(url,debug=self.config["debug"])
+        folders = await self.client.json(url, debug=self.config["debug"])
         for folder in folders:
             if folder["full_name"].startswith("course files"):
                 folder["full_name"] = folder["full_name"][len("course files") :]

--- a/canvassyncer/__main__.py
+++ b/canvassyncer/__main__.py
@@ -1,6 +1,5 @@
 import argparse
 import asyncio
-from distutils.log import debug
 import json
 import ntpath
 import os


### PR DESCRIPTION
1. Change from umjicanvas.com to jicanvas.com.
2. Allow retry in `clientGetJson`. Otherwise, there will be `403 Forbidden (Rate Limit Exceeded)` appearing.
`