### PR TITLE
allow remove old config

### DIFF
--- a/canvassyncer/__main__.py
+++ b/canvassyncer/__main__.py
@@ -353,7 +353,7 @@ def initConfig():
         else:
             defaultValOnRemove = ""
         tipStr = f"(Default: {defaultVal})" if defaultVal else ""
-        tipRemove = f"(If you input remove, value will change to {defaultValOnRemove})" if defaultValOnRemove != "" else f"(If you input remove, value will change to empty)"
+        tipRemove = f"(If you input remove, value will change to " + (f"{defaultValOnRemove})" if defaultValOnRemove != "" else "empty)")
         res = input(f"{promptStr}{tipStr}{tipRemove}: ").strip()
         if not res:
             res = defaultVal

--- a/canvassyncer/__main__.py
+++ b/canvassyncer/__main__.py
@@ -348,15 +348,17 @@ def initConfig():
         elif isinstance(defaultVal, list):
             defaultVal = " ".join((str(val) for val in defaultVal))
         defaultVal = str(defaultVal)
+        if defaultValOnMissing is not None:
+            defaultValOnRemove = defaultValOnMissing
+        else:
+            defaultValOnRemove = ""
         tipStr = f"(Default: {defaultVal})" if defaultVal else ""
-        res = input(f"{promptStr}{tipStr}: ").strip()
+        tipRemove = f"(If you input remove, value will change to {defaultValOnRemove})" if defaultValOnRemove != "" else f"(If you input remove, value will change to empty)"
+        res = input(f"{promptStr}{tipStr}{tipRemove}: ").strip()
         if not res:
             res = defaultVal
         elif res == "remove":
-            if defaultValOnMissing is not None:
-                res = defaultValOnMissing
-            else:
-                res = ""
+            res = defaultValOnRemove
         return res
 
     print("Generating new config file...")

--- a/canvassyncer/__main__.py
+++ b/canvassyncer/__main__.py
@@ -353,7 +353,7 @@ def initConfig():
         else:
             defaultValOnRemove = ""
         tipStr = f"(Default: {defaultVal})" if defaultVal else ""
-        tipRemove = f"(If you input remove, value will change to " + (f"{defaultValOnRemove})" if defaultValOnRemove != "" else "empty)")
+        tipRemove = "(If you input remove, value will change to " + (f"{defaultValOnRemove})" if defaultValOnRemove != "" else "empty)")
         res = input(f"{promptStr}{tipStr}{tipRemove}: ").strip()
         if not res:
             res = defaultVal

--- a/canvassyncer/__main__.py
+++ b/canvassyncer/__main__.py
@@ -353,7 +353,7 @@ def initConfig():
         else:
             defaultValOnRemove = ""
         tipStr = f"(Default: {defaultVal})" if defaultVal else ""
-        tipRemove = "(If you input remove, value will change to " + (f"{defaultValOnRemove})" if defaultValOnRemove != "" else "empty)")
+        tipRemove = "(If you input remove, value will become " + (f"{defaultValOnRemove})" if defaultValOnRemove != "" else "empty)")
         res = input(f"{promptStr}{tipStr}{tipRemove}: ").strip()
         if not res:
             res = defaultVal

--- a/canvassyncer/__main__.py
+++ b/canvassyncer/__main__.py
@@ -352,6 +352,11 @@ def initConfig():
         res = input(f"{promptStr}{tipStr}: ").strip()
         if not res:
             res = defaultVal
+        elif res == "remove":
+            if defaultValOnMissing is not None:
+                res = defaultValOnMissing
+            else:
+                res = ""
         return res
 
     print("Generating new config file...")


### PR DESCRIPTION
Fix https://github.com/BoYanZh/Canvas-Syncer/issues/24.
When using `-r`, if input `remove`, it will not keep the old config. Instead, it will store the default value.